### PR TITLE
Returning rowcount of expanded rows

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -954,6 +954,8 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
 
       if (this.groupedRows) {
         return this.groupedRows.length;
+      } else if (this.treeFromRelation != null && this.treeToRelation != null) {
+        return this._internalRows.length;
       } else {
         return val.length;
       }


### PR DESCRIPTION
Promised PR. Fixed scrolling height - row count now returns the count of visible rows instead of all rows.

You can consider merging your branch with upstream master, so possible owner sees that PR is at least auto-merging and in buildable state.